### PR TITLE
Prepare for cran pt. 2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,5 +43,5 @@ Our procedures for contributing bigger changes, code in particular, generally fo
 ## Code of Conduct
 
 Please note that the hubEnsembles project is released with a
-[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By contributing to this
-project you agree to abide by its terms.
+[Contributor Code of Conduct](https://hubverse-org.github.io/hubEnsembles/CODE_OF_CONDUCT.html). 
+By contributing to this project you agree to abide by its terms.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ scrap code.r
 hubEnsembles.code-workspace
 .Rprofile
 Rplot.png
+/dev
+revdep/

--- a/R/linear_pool.R
+++ b/R/linear_pool.R
@@ -30,7 +30,7 @@
 #' Steps 1 and 2 in this process are performed by `distfromq::make_q_fn`.
 #'
 #' @return a `model_out_tbl` object of ensemble predictions. Note that any
-#'   additional columns in the input `model_outputs` are dropped.
+#'   additional columns in the input `model_out_tbl` are dropped.
 #'
 #' @export
 #'
@@ -67,7 +67,7 @@
 #'           check.attributes=FALSE)
 #'
 
-linear_pool <- function(model_outputs, weights = NULL,
+linear_pool <- function(model_out_tbl, weights = NULL,
                         weights_col_name = "weight",
                         model_id = "hub-ensemble",
                         task_id_cols = NULL,
@@ -76,18 +76,18 @@ linear_pool <- function(model_outputs, weights = NULL,
 
   # validate_ensemble_inputs
   valid_types <- c("mean", "quantile", "cdf", "pmf")
-  validated_inputs <- model_outputs |>
+  validated_inputs <- model_out_tbl |>
     validate_ensemble_inputs(weights = weights,
                              weights_col_name = weights_col_name,
                              task_id_cols = task_id_cols,
                              valid_output_types = valid_types)
 
-  model_outputs_validated <- validated_inputs$model_outputs
+  model_out_tbl_validated <- validated_inputs$model_out_tbl
   weights_validated <- validated_inputs$weights
   task_id_cols_validated <- validated_inputs$task_id_cols
 
   # calculate linear opinion pool for different types
-  ensemble_model_outputs <- model_outputs_validated |>
+  ensemble_model_outputs <- model_out_tbl_validated |>
     dplyr::group_split("output_type") |>
     purrr::map(.f = function(split_outputs) {
       type <- split_outputs$output_type[1]

--- a/R/linear_pool_quantile.R
+++ b/R/linear_pool_quantile.R
@@ -8,13 +8,13 @@
 #' @return a `model_out_tbl` object of ensemble predictions for the `quantile` output type.
 #' @importFrom rlang .data
 
-linear_pool_quantile <- function(model_outputs, weights = NULL,
+linear_pool_quantile <- function(model_out_tbl, weights = NULL,
                                  weights_col_name = "weight",
                                  model_id = "hub-ensemble",
                                  task_id_cols = NULL,
                                  n_samples = 1e4,
                                  ...) {
-  quantile_levels <- unique(model_outputs$output_type_id)
+  quantile_levels <- unique(model_out_tbl$output_type_id)
 
   if (is.null(weights)) {
     group_by_cols <- task_id_cols
@@ -22,7 +22,7 @@ linear_pool_quantile <- function(model_outputs, weights = NULL,
   } else {
     weight_by_cols <- colnames(weights)[colnames(weights) != weights_col_name]
 
-    model_outputs <- model_outputs |>
+    model_out_tbl <- model_out_tbl |>
       dplyr::left_join(weights, by = weight_by_cols)
 
     agg_args <- c(list(x = quote(.data[["pred_qs"]]),
@@ -34,7 +34,7 @@ linear_pool_quantile <- function(model_outputs, weights = NULL,
   }
 
   sample_q_lvls <- seq(from = 0, to = 1, length.out = n_samples + 2)[2:n_samples]
-  quantile_outputs <- model_outputs |>
+  quantile_outputs <- model_out_tbl |>
     dplyr::group_by(model_id, dplyr::across(dplyr::all_of(group_by_cols))) |>
     dplyr::summarize(
       pred_qs = list(

--- a/R/simple_ensemble.R
+++ b/R/simple_ensemble.R
@@ -41,9 +41,38 @@
 #'   any additional columns in the input `model_outputs` are dropped.
 #'
 #' @export
+#'
+#' @examples
+#' # Calculate a weighted median in two ways
+#' model_outputs <- expand.grid(stringsAsFactors = FALSE,
+#'                              model_id = letters[1:4],
+#'                              location = c("222", "888"),
+#'                              horizon = 1, #week
+#'                              target = "inc death",
+#'                              target_date = as.Date("2021-12-25"),
+#'                              output_type = "quantile",
+#'                              output_type_id = c(.1, .5, .9),
+#'                              value = NA_real_)
+#'
+#' model_outputs$value <- c(10, 30, 15, 20, 100, 300, 400, 250, 40, 40, 45, 50,
+#'                          150, 325, 500, 300, 60, 70, 75, 80, 250, 350, 500, 350)
+#'
+#' fweights <- expand.grid(stringsAsFactors = FALSE,
+#'                         model_id = letters[1:4],
+#'                         location = c("222", "888"),
+#'                         weight = NA_real_)
+#' fweights$weight <- c(0.1 * (1:4), 0.1 * (4:1))
+#'
+#' weighted_median1 <- simple_ensemble(model_outputs, weights = fweights,
+#'                                     agg_fun = stats::median)
+#' weighted_median2 <- simple_ensemble(model_outputs, weights = fweights,
+#'                                      agg_fun = matrixStats::weightedMedian)
+#' all.equal(weighted_median1, weighted_median2)
+#'
+
 simple_ensemble <- function(model_outputs, weights = NULL,
                             weights_col_name = "weight",
-                            agg_fun = "mean", agg_args = list(),
+                            agg_fun = mean, agg_args = list(),
                             model_id = "hub-ensemble",
                             task_id_cols = NULL) {
 
@@ -72,7 +101,7 @@ simple_ensemble <- function(model_outputs, weights = NULL,
 
     if (identical(agg_fun, mean)) {
       agg_fun <- matrixStats::weightedMean
-    } else if (identical(agg_fun, median)) {
+    } else if (identical(agg_fun, stats::median)) {
       agg_fun <- matrixStats::weightedMedian
     }
 

--- a/R/validate_output_type_ids.R
+++ b/R/validate_output_type_ids.R
@@ -2,10 +2,10 @@
 #' of values for task id variables and output type, all models provided the same
 #' set of output type ids. This check only applies to the `cdf`, `pmf`, and
 #' `quantile` output types to ensure the resulting distribution is valid.
-#' @param model_outputs an object of class `model_out_tbl` with component
+#' @param model_out_tbl an object of class `model_out_tbl` with component
 #'   model outputs (e.g., predictions).
 #' @param task_id_cols `character` vector with names of columns in
-#'   `model_outputs` that specify modeling tasks.
+#'   `model_out_tbl` that specify modeling tasks.
 #' @details If the ensembling function intended to be used is `"simple_ensemble"`,
 #'   the valid output types are `mean`, `median`, `quantile`, `cdf`, and `pmf`.
 #'   If the ensembling function will be `"linear_pool"`, the valid output types
@@ -16,8 +16,8 @@
 #'
 #' @importFrom rlang .data
 
-validate_output_type_ids <- function(model_outputs, task_id_cols) {
-  same_output_id <- model_outputs |>
+validate_output_type_ids <- function(model_out_tbl, task_id_cols) {
+  same_output_id <- model_out_tbl |>
     dplyr::filter(.data[["output_type"]] %in% c("cdf", "pmf", "quantile")) |>
     dplyr::group_by(dplyr::across(c(dplyr::all_of(task_id_cols), "model_id", "output_type"))) |>
     dplyr::summarize(output_type_id_list = list(sort(.data[["output_type_id"]]))) |>
@@ -30,7 +30,7 @@ validate_output_type_ids <- function(model_outputs, task_id_cols) {
   false_counter <- sum(!same_output_id)
   if (false_counter != 0) {
     cli::cli_abort(c(
-      "x" = "{.arg model_outputs} contains {.val {false_counter}} invalid distributions.",
+      "x" = "{.arg model_out_tbl} contains {.val {false_counter}} invalid distributions.",
       "i" = "Within each group defined by a combination of task id variables
              and output type, all models must provide the same set of
              output type ids"

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,11 +46,9 @@ library(hubEnsembles)
 ***
 
 ## Code of Conduct
-
-Please note that the hubEnsembles package is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By contributing to this project, you agree to abide by its terms.
-
+Please note that the hubEnsembles package is released with a [Contributor Code of Conduct](https://hubverse-org.github.io/hubEnsembles/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
 
 ## Contributing
 
-Interested in contributing back to the open-source hubverse project?
-Learn more about how to [get involved in the hubverse community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubEnsembles package](.github/CONTRIBUTING.md).
+Interested in contributing back to the open-source Hubverse project?
+Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubEnsembles package](https://hubverse-org.github.io/hubEnsembles/CONTRIBUTING.html).

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 The goal of hubEnsembles is to provide standard implementations of
 commonly used methods for ensembling model outputs. The hubEnsembles
 package is part of [the hubverse
-project](https://hubverse.io/en/latest/) and expects all
-input data to the key functions to be formatted as an object of a
-[`model_out_tbl`
+project](https://hubverse.io/en/latest/) and expects all input data to
+the key functions to be formatted as an object of a [`model_out_tbl`
 class](https://hubverse-org.github.io/hubUtils/reference/as_model_out_tbl.html).
 
 ## Installation
@@ -41,13 +40,14 @@ library(hubEnsembles)
 ## Code of Conduct
 
 Please note that the hubEnsembles package is released with a
-[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By
-contributing to this project, you agree to abide by its terms.
+[Contributor Code of
+Conduct](https://hubverse-org.github.io/hubEnsembles/CODE_OF_CONDUCT.html).
+By contributing to this project, you agree to abide by its terms.
 
 ## Contributing
 
-Interested in contributing back to the open-source hubverse project?
-Learn more about how to [get involved in the hubverse
-community](https://hubverse.io/en/latest/overview/contribute.html) or
+Interested in contributing back to the open-source Hubverse project?
+Learn more about how to [get involved in the Hubverse
+Community](https://hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubEnsembles
-package](.github/CONTRIBUTING.md).
+package](https://hubverse-org.github.io/hubEnsembles/CONTRIBUTING.html).

--- a/man/linear_pool.Rd
+++ b/man/linear_pool.Rd
@@ -8,7 +8,7 @@ each combination of model task, output type, and output type id. Supported
 output types include \code{mean}, \code{quantile}, \code{cdf}, and \code{pmf}.}
 \usage{
 linear_pool(
-  model_outputs,
+  model_out_tbl,
   weights = NULL,
   weights_col_name = "weight",
   model_id = "hub-ensemble",
@@ -18,7 +18,7 @@ linear_pool(
 )
 }
 \arguments{
-\item{model_outputs}{an object of class \code{model_out_tbl} with component
+\item{model_out_tbl}{an object of class \code{model_out_tbl} with component
 model outputs (e.g., predictions).}
 
 \item{weights}{an optional \code{data.frame} with component model weights. If
@@ -35,8 +35,8 @@ with model weights. Defaults to \code{"weight"}}
 ensemble model.}
 
 \item{task_id_cols}{\code{character} vector with names of columns in
-\code{model_outputs} that specify modeling tasks. Defaults to \code{NULL}, in which
-case all columns in \code{model_outputs} other than \code{"model_id"}, \code{"output_type"},
+\code{model_out_tbl} that specify modeling tasks. Defaults to \code{NULL}, in which
+case all columns in \code{model_out_tbl} other than \code{"model_id"}, \code{"output_type"},
 \code{"output_type_id"}, and \code{"value"} are used as task ids.}
 
 \item{n_samples}{\code{numeric} that specifies the number of samples to use when
@@ -48,7 +48,7 @@ and quantile values for \code{output_type} \code{"quantile"}.}
 }
 \value{
 a \code{model_out_tbl} object of ensemble predictions. Note that any
-additional columns in the input \code{model_outputs} are dropped.
+additional columns in the input \code{model_out_tbl} are dropped.
 }
 \description{
 Compute ensemble model outputs as a linear pool, otherwise known as a

--- a/man/simple_ensemble.Rd
+++ b/man/simple_ensemble.Rd
@@ -7,7 +7,7 @@ each combination of model task, output type, and output type id. Supported
 output types include \code{mean}, \code{median}, \code{quantile}, \code{cdf}, and \code{pmf}.}
 \usage{
 simple_ensemble(
-  model_outputs,
+  model_out_tbl,
   weights = NULL,
   weights_col_name = "weight",
   agg_fun = mean,
@@ -17,7 +17,7 @@ simple_ensemble(
 )
 }
 \arguments{
-\item{model_outputs}{an object of class \code{model_out_tbl} with component
+\item{model_out_tbl}{an object of class \code{model_out_tbl} with component
 model outputs (e.g., predictions).}
 
 \item{weights}{an optional \code{data.frame} with component model weights. If
@@ -41,13 +41,13 @@ to \code{agg_fun}.}
 ensemble model.}
 
 \item{task_id_cols}{\code{character} vector with names of columns in
-\code{model_outputs} that specify modeling tasks. Defaults to \code{NULL}, in which
-case all columns in \code{model_outputs} other than \code{"model_id"}, \code{"output_type"},
+\code{model_out_tbl} that specify modeling tasks. Defaults to \code{NULL}, in which
+case all columns in \code{model_out_tbl} other than \code{"model_id"}, \code{"output_type"},
 \code{"output_type_id"}, and \code{"value"} are used as task ids.}
 }
 \value{
 a \code{model_out_tbl} object of ensemble predictions. Note that
-any additional columns in the input \code{model_outputs} are dropped.
+any additional columns in the input \code{model_out_tbl} are dropped.
 }
 \description{
 Compute ensemble model outputs by summarizing component model outputs for

--- a/man/simple_ensemble.Rd
+++ b/man/simple_ensemble.Rd
@@ -10,7 +10,7 @@ simple_ensemble(
   model_outputs,
   weights = NULL,
   weights_col_name = "weight",
-  agg_fun = "mean",
+  agg_fun = mean,
   agg_args = list(),
   model_id = "hub-ensemble",
   task_id_cols = NULL
@@ -67,4 +67,32 @@ would need to be written. For weighted methods, \code{agg_fun = "mean"} and
 \code{matrixStats::weightedMedian} respectively. For \code{matrixStats::weightedMedian},
 the argument \code{interpolate} is automatically set to FALSE to circumvent a
 calculation issue that results in invalid distributions.
+}
+\examples{
+# Calculate a weighted median in two ways
+model_outputs <- expand.grid(stringsAsFactors = FALSE,
+                             model_id = letters[1:4],
+                             location = c("222", "888"),
+                             horizon = 1, #week
+                             target = "inc death",
+                             target_date = as.Date("2021-12-25"),
+                             output_type = "quantile",
+                             output_type_id = c(.1, .5, .9),
+                             value = NA_real_)
+
+model_outputs$value <- c(10, 30, 15, 20, 100, 300, 400, 250, 40, 40, 45, 50,
+                         150, 325, 500, 300, 60, 70, 75, 80, 250, 350, 500, 350)
+
+fweights <- expand.grid(stringsAsFactors = FALSE,
+                        model_id = letters[1:4],
+                        location = c("222", "888"),
+                        weight = NA_real_)
+fweights$weight <- c(0.1 * (1:4), 0.1 * (4:1))
+
+weighted_median1 <- simple_ensemble(model_outputs, weights = fweights,
+                                    agg_fun = stats::median)
+weighted_median2 <- simple_ensemble(model_outputs, weights = fweights,
+                                     agg_fun = matrixStats::weightedMedian)
+all.equal(weighted_median1, weighted_median2)
+
 }

--- a/tests/testthat/test-simple_ensemble.R
+++ b/tests/testthat/test-simple_ensemble.R
@@ -205,17 +205,17 @@ test_that("(weighted) medians and means correctly calculated", {
   weighted_mean_expected$value <- weighted_mean_vals
   weighted_median_expected$value <- weighted_median_vals
 
-  median_actual <- simple_ensemble(model_outputs = model_outputs,
+  median_actual <- simple_ensemble(model_out_tbl = model_outputs,
                                    weights = NULL,
                                    agg_fun = "median")
-  mean_actual <- simple_ensemble(model_outputs = model_outputs,
+  mean_actual <- simple_ensemble(model_out_tbl = model_outputs,
                                  weights = NULL,
                                  agg_fun = "mean")
 
-  weighted_median_actual <- simple_ensemble(model_outputs = model_outputs,
+  weighted_median_actual <- simple_ensemble(model_out_tbl = model_outputs,
                                             weights = fweight,
                                             agg_fun = "median")
-  weighted_mean_actual <- simple_ensemble(model_outputs = model_outputs,
+  weighted_mean_actual <- simple_ensemble(model_out_tbl = model_outputs,
                                           weights = fweight,
                                           agg_fun = "mean")
 
@@ -237,10 +237,10 @@ test_that("(weighted) medians and means work with alternate name for weights col
                     weights_col_name = "w",
                     agg_fun = "mean")
 
-  weighted_median_expected <- simple_ensemble(model_outputs = model_outputs,
+  weighted_median_expected <- simple_ensemble(model_out_tbl = model_outputs,
                                               weights = fweight,
                                               agg_fun = "median")
-  weighted_mean_expected <- simple_ensemble(model_outputs = model_outputs,
+  weighted_mean_expected <- simple_ensemble(model_out_tbl = model_outputs,
                                             weights = fweight,
                                             agg_fun = "mean")
 
@@ -250,10 +250,10 @@ test_that("(weighted) medians and means work with alternate name for weights col
 
 test_that("passing agg_fun as symbol or character results in identical behaviour", {
 
-  weighted_mean_actual_char <- simple_ensemble(model_outputs = model_outputs,
+  weighted_mean_actual_char <- simple_ensemble(model_out_tbl = model_outputs,
                                                weights = fweight,
                                                agg_fun = "mean")
-  weighted_mean_actual_symbol <- simple_ensemble(model_outputs = model_outputs,
+  weighted_mean_actual_symbol <- simple_ensemble(model_out_tbl = model_outputs,
                                                  weights = fweight,
                                                  agg_fun = mean)
 

--- a/tests/testthat/test-validate_ensemble_inputs.R
+++ b/tests/testthat/test-validate_ensemble_inputs.R
@@ -101,23 +101,23 @@ test_that("value column in weights generates error", {
   )
 })
 
-test_that("column not from model_outputs in weights generates error", {
+test_that("column not from model_out_tbl in weights generates error", {
   expect_error(
     model_outputs |>
       validate_ensemble_inputs(
         weights = fweight |> dplyr::mutate(age_group = "65+"),
         valid_output_types = "quantile"
       ),
-    "not present in `model_outputs`:", fixed = TRUE
+    "not present in `model_out_tbl`:", fixed = TRUE
   )
 })
 
-test_that("weights column already in model_outputs generates error", {
+test_that("weights column already in model_out_tbl generates error", {
   expect_error(
     model_outputs |>
       dplyr::mutate(weight = "a") |>
       validate_ensemble_inputs(weights = fweight, valid_output_types = c("quantile")),
-    "is already a column in `model_outputs`", fixed = TRUE
+    "is already a column in `model_out_tbl`", fixed = TRUE
   )
 })
 
@@ -133,7 +133,7 @@ test_that("error if weights depend on output_type_id for cdf and pmf output_type
   )
 })
 
-test_that("validated model_output is a model_out_tbl", {
+test_that("validated model outputs is a model_out_tbl", {
   validated_outputs <- validate_ensemble_inputs(model_outputs, valid_output_types = "quantile")[[1]]
   expect_s3_class(validated_outputs, "model_out_tbl")
 })


### PR DESCRIPTION
A few more changes to prepare `hubEnsembles` for a CRAN submission:
- Ensure all exported functions have examples
- Replace any relative file links with URLs to the pkgdown site
- Change model outputs parameter name to `model_out_tbl` to reflect standardization across the hubverse