### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubEnsembles`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version/hubEnsembles)](https://CRAN.R-project.org/package=hubEnsembles)
 <!-- badges: end -->
 
-The goal of hubEnsembles is to provide standard implementations of commonly used methods for ensembling model outputs. The hubEnsembles package is part of [the hubverse project](https://hubverse.io/en/latest/) and expects all input data to the key functions to be formatted as an object of a [`model_out_tbl` class](https://hubverse-org.github.io/hubUtils/reference/as_model_out_tbl.html).
+The goal of hubEnsembles is to provide standard implementations of commonly used methods for ensembling model outputs. The hubEnsembles package is part of [the hubverse project](https://docs.hubverse.io/en/latest/) and expects all input data to the key functions to be formatted as an object of a [`model_out_tbl` class](https://hubverse-org.github.io/hubUtils/reference/as_model_out_tbl.html).
 
 ## Installation
 
@@ -52,6 +52,6 @@ Please note that the hubEnsembles package is released with a [Contributor Code o
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubEnsembles package](https://hubverse-org.github.io/hubEnsembles/CONTRIBUTING.html).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubEnsembles package](https://hubverse-org.github.io/hubEnsembles/CONTRIBUTING.html).
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ status](https://www.r-pkg.org/badges/version/hubEnsembles)](https://CRAN.R-proje
 The goal of hubEnsembles is to provide standard implementations of
 commonly used methods for ensembling model outputs. The hubEnsembles
 package is part of [the hubverse
-project](https://hubverse.io/en/latest/) and expects all input data to
+project](https://docs.hubverse.io/en/latest/) and expects all input data to
 the key functions to be formatted as an object of a [`model_out_tbl`
 class](https://hubverse-org.github.io/hubUtils/reference/as_model_out_tbl.html).
 
@@ -53,6 +53,6 @@ By contributing to this project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubEnsembles
 package](https://hubverse-org.github.io/hubEnsembles/CONTRIBUTING.html).

--- a/vignettes/articles/hubEnsembles.Rmd
+++ b/vignettes/articles/hubEnsembles.Rmd
@@ -320,7 +320,7 @@ When specifically requesting a linear pool made up of a **subset of the input sa
 
 For example, a compound task could be predicting the number of weekly incident influenza hospitalizations (`"target"`) in Massachusetts (`"location"`) starting on November 19, 2022 (`"reference_date"`). Here, `"horizon"` is not part of the compound task ID set, indicating that sample predictions made at each horizon depend on those for the other horizons within every compound task for the sample output type. Each sample can therefore be interpreted as a trajectory giving a possible path of hospitalizations over time.
 
-If samples are not expected to capture dependence across the levels of any task ID variables (that is, we are summarizing predictions for marginal distributions), the `compound_taskid_set` consists of all task ID variables. Please see the [hubverse documentation on samples](https://hubverse.io/en/latest/user-guide/sample-output-type.html) for more information about compound tasks.
+If samples are not expected to capture dependence across the levels of any task ID variables (that is, we are summarizing predictions for marginal distributions), the `compound_taskid_set` consists of all task ID variables. Please see the [hubverse documentation on samples](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html) for more information about compound tasks.
 
 Thus, in this example, those three task id variables (`"reference_date"`, `"location"`, and `"target"`) make up the compound task ID set that is specified in the call to `linear_pool()`. The `"target_end_date"` for a given forecast is derived from the combination of `"reference_date"` and `"horizon"`, and so it is specified as the argument for `derived_tasks`.
 


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.