### PR TITLE
Update documentation to reflect that n_ouput_samples can be not NULL

### DIFF
--- a/R/linear_pool.R
+++ b/R/linear_pool.R
@@ -24,9 +24,9 @@
 #'   values depend on that of other task ID variables). Defaults to NULL, meaning
 #'   there are no derived task IDs.
 #' @param n_output_samples `numeric` that specifies how many sample forecasts to
-#'   return per unique combination of task IDs. Currently the only supported value
-#'   is NULL, in which case all provided component model samples are collected and
-#'   returned.
+#'   return per unique combination of task IDs. Cannot exceed the number of provided
+#'   samples per compound unit (defined by the compound task id set). Defaults to NULL,
+#'   in which case all provided component model samples are collected and returned.
 #' @param derived_tasks `r lifecycle::badge("deprecated")` Use `derived_task_ids`
 #'   instead. A `character` vector of derived task IDs.
 #'

--- a/man/linear_pool.Rd
+++ b/man/linear_pool.Rd
@@ -65,9 +65,9 @@ there are no derived task IDs.}
 calculating quantiles from an estimated quantile function. Defaults to \code{1e4}.}
 
 \item{n_output_samples}{\code{numeric} that specifies how many sample forecasts to
-return per unique combination of task IDs. Currently the only supported value
-is NULL, in which case all provided component model samples are collected and
-returned.}
+return per unique combination of task IDs. Cannot exceed the number of provided
+samples per compound unit (defined by the compound task id set). Defaults to NULL,
+in which case all provided component model samples are collected and returned.}
 
 \item{...}{parameters that are passed to \code{distfromq::make_q_fn}, specifying
 details of how to estimate a quantile function from provided quantile levels


### PR DESCRIPTION
hubEnsembles v1.0.0 now allows a subset of samples to be requested for a linear pool of samples