### PR TITLE
Fix dplyr 1.2.x compatibility in mutate() calls

### DIFF
--- a/R/linear_pool_quantile.R
+++ b/R/linear_pool_quantile.R
@@ -17,6 +17,7 @@ linear_pool_quantile <- function(
   n_samples = 1e4,
   ...
 ) {
+  ensemble_model_id <- model_id
   quantile_levels <- unique(model_out_tbl$output_type_id)
 
   if (is.null(weights)) {
@@ -69,7 +70,7 @@ linear_pool_quantile <- function(
       .groups = "drop"
     ) |>
     tidyr::unnest(cols = tidyselect::all_of(c("output_type_id", "value"))) |>
-    dplyr::mutate(model_id = .env$model_id, .before = 1) |>
+    dplyr::mutate(model_id = ensemble_model_id, .before = 1) |>
     dplyr::mutate(output_type = "quantile", .before = "output_type_id") |>
     dplyr::ungroup()
 

--- a/R/linear_pool_quantile.R
+++ b/R/linear_pool_quantile.R
@@ -69,7 +69,7 @@ linear_pool_quantile <- function(
       .groups = "drop"
     ) |>
     tidyr::unnest(cols = tidyselect::all_of(c("output_type_id", "value"))) |>
-    dplyr::mutate(model_id = model_id, .before = 1) |>
+    dplyr::mutate(model_id = .env$model_id, .before = 1) |>
     dplyr::mutate(output_type = "quantile", .before = "output_type_id") |>
     dplyr::ungroup()
 

--- a/R/linear_pool_sample.R
+++ b/R/linear_pool_sample.R
@@ -93,7 +93,7 @@ linear_pool_sample <- function(
   model_out_tbl |>
     make_sample_indices_unique() |>
     dplyr::select(-"model_id") |>
-    dplyr::mutate(model_id = model_id, .before = 1)
+    dplyr::mutate(model_id = .env$model_id, .before = 1)
 }
 
 

--- a/R/linear_pool_sample.R
+++ b/R/linear_pool_sample.R
@@ -26,6 +26,7 @@ linear_pool_sample <- function(
   compound_taskid_set,
   n_output_samples = NULL
 ) {
+  ensemble_model_id <- model_id
   validate_sample_inputs(
     model_out_tbl,
     weights,
@@ -93,7 +94,7 @@ linear_pool_sample <- function(
   model_out_tbl |>
     make_sample_indices_unique() |>
     dplyr::select(-"model_id") |>
-    dplyr::mutate(model_id = .env$model_id, .before = 1)
+    dplyr::mutate(model_id = ensemble_model_id, .before = 1)
 }
 
 

--- a/R/simple_ensemble.R
+++ b/R/simple_ensemble.R
@@ -111,7 +111,7 @@ simple_ensemble <- function(
   ensemble_model_outputs <- model_out_tbl_validated |>
     dplyr::group_by(dplyr::across(dplyr::all_of(group_by_cols))) |>
     dplyr::summarize(value = do.call(agg_fun, args = agg_args)) |>
-    dplyr::mutate(model_id = model_id, .before = 1) |>
+    dplyr::mutate(model_id = .env$model_id, .before = 1) |>
     dplyr::ungroup() |>
     hubUtils::as_model_out_tbl()
 

--- a/R/simple_ensemble.R
+++ b/R/simple_ensemble.R
@@ -73,6 +73,7 @@ simple_ensemble <- function(
       valid_output_types = valid_types
     )
 
+  ensemble_model_id <- model_id
   model_out_tbl_validated <- validated_inputs$model_out_tbl
   weights_validated <- validated_inputs$weights
   task_id_cols_validated <- validated_inputs$task_id_cols
@@ -111,7 +112,7 @@ simple_ensemble <- function(
   ensemble_model_outputs <- model_out_tbl_validated |>
     dplyr::group_by(dplyr::across(dplyr::all_of(group_by_cols))) |>
     dplyr::summarize(value = do.call(agg_fun, args = agg_args)) |>
-    dplyr::mutate(model_id = .env$model_id, .before = 1) |>
+    dplyr::mutate(model_id = ensemble_model_id, .before = 1) |>
     dplyr::ungroup() |>
     hubUtils::as_model_out_tbl()
 

--- a/tests/testthat/test-linear_pool.R
+++ b/tests/testthat/test-linear_pool.R
@@ -4,10 +4,6 @@ test_that("(#128) linear pool will group by output_type", {
   forecast <- forecast[
     forecast$output_type %in% c("mean", "quantile", "cdf", "pmf", "sample"),
   ]
-  skip_if(
-    nrow(forecast) == 0L,
-    "forecast_outputs has no output types supported by linear_pool"
-  )
   expect_no_error({
     res <- linear_pool(
       forecast,

--- a/tests/testthat/test-linear_pool.R
+++ b/tests/testthat/test-linear_pool.R
@@ -1,7 +1,13 @@
 test_that("(#128) linear pool will group by output_type", {
   skip_if_not_installed("hubExamples")
   forecast <- hubExamples::forecast_outputs
-  forecast <- forecast[!forecast$output_type %in% c("median"), ]
+  forecast <- forecast[
+    forecast$output_type %in% c("mean", "quantile", "cdf", "pmf", "sample"),
+  ]
+  skip_if(
+    nrow(forecast) == 0L,
+    "forecast_outputs has no output types supported by linear_pool"
+  )
   expect_no_error({
     res <- linear_pool(
       forecast,

--- a/tests/testthat/test-linear_pool.R
+++ b/tests/testthat/test-linear_pool.R
@@ -231,19 +231,18 @@ test_that("(weighted) quantiles correctly calculated", {
   # F_1 = N(-3, 1), F_2 = N(0,1), and F_3 = N(3, 1)
   # The linear pool is a (weighted) mixture with cdf F(x) = \sum_m w_m F_m(x)
   # We test with equal weights w_m = 1/3 and with weights w_1 = 0.25, w_2 = 0.5, w_3 = 0.25
-  quantile_expected <-
-    weighted_quantile_expected <-
-      data.frame(
-        stringsAsFactors = FALSE,
-        model_id = "hub-ensemble",
-        location = "111",
-        horizon = 1,
-        target = "inc death",
-        target_date = as.Date("2021-12-25"),
-        output_type = "quantile",
-        output_type_id = rep(NA, 21),
-        value = NA_real_
-      )
+  quantile_expected <- weighted_quantile_expected <-
+    data.frame(
+      stringsAsFactors = FALSE,
+      model_id = "hub-ensemble",
+      location = "111",
+      horizon = 1,
+      target = "inc death",
+      target_date = as.Date("2021-12-25"),
+      output_type = "quantile",
+      output_type_id = rep(NA, 21),
+      value = NA_real_
+    )
 
   quantile_values <- weighted_quantile_values <- seq(
     from = -5,
@@ -353,19 +352,18 @@ test_that("(weighted) quantiles correctly calculated - lognormal family", {
     by = 0.5
   )) # expected
 
-  quantile_expected <-
-    weighted_quantile_expected <-
-      data.frame(
-        stringsAsFactors = FALSE,
-        model_id = "hub-ensemble",
-        location = "111",
-        horizon = 1,
-        target = "inc death",
-        target_date = as.Date("2021-12-25"),
-        output_type = "quantile",
-        output_type_id = rep(NA, length(quantile_values)),
-        value = NA_real_
-      )
+  quantile_expected <- weighted_quantile_expected <-
+    data.frame(
+      stringsAsFactors = FALSE,
+      model_id = "hub-ensemble",
+      location = "111",
+      horizon = 1,
+      target = "inc death",
+      target_date = as.Date("2021-12-25"),
+      output_type = "quantile",
+      output_type_id = rep(NA, length(quantile_values)),
+      value = NA_real_
+    )
 
   output_prob <- stats::plnorm(quantile_values, mean = -3) /
     3 +
@@ -619,8 +617,7 @@ test_that("If the specified `compound_taskid_set` is incompatible with component
 })
 
 
-test_that("Unequal numbers of samples across component models for unique combination of
-  compound task ID set vars throws an error", {
+test_that("Unequal numbers of samples across component models for unique compound task ID set vars throws an error", {
   # there are four models, "a", "b", "c", and "d".
   # The first three models each submit 3 samples, while model "d" submits only 1 sample.
   # We expect an error in this situation, because our methods currently do not support it.

--- a/tests/testthat/test-simple_ensemble.R
+++ b/tests/testthat/test-simple_ensemble.R
@@ -236,18 +236,17 @@ test_that("group_by(output_type_id) produces expected results", {
 
 
 test_that("(weighted) medians and means correctly calculated", {
-  median_expected <- mean_expected <-
-    weighted_median_expected <- weighted_mean_expected <-
-      data.frame(
-        model_id = "hub-ensemble",
-        location = rep(c("222", "888"), each = 3),
-        horizon = 1,
-        target = "inc death",
-        target_date = as.Date("2021-12-25"),
-        output_type = "quantile",
-        output_type_id = rep(c(.1, .5, .9), 2),
-        value = NA_real_
-      )
+  median_expected <- mean_expected <- weighted_median_expected <- weighted_mean_expected <-
+    data.frame(
+      model_id = "hub-ensemble",
+      location = rep(c("222", "888"), each = 3),
+      horizon = 1,
+      target = "inc death",
+      target_date = as.Date("2021-12-25"),
+      output_type = "quantile",
+      output_type_id = rep(c(.1, .5, .9), 2),
+      value = NA_real_
+    )
 
   median_vals <- sapply(list(v2_1, v2_5, v2_9, v8_1, v8_5, v8_9), median)
   mean_vals <- sapply(list(v2_1, v2_5, v2_9, v8_1, v8_5, v8_9), mean)


### PR DESCRIPTION
Originally opened in an attempt to fix the failing CI checks that began ~April 2026, which was misdiagnosed as being the result of the release of `dplyr` 1.2.1 (see below). The actual issue originated from `hubExamples`/`hubData`/`arrow`, which is documented in https://github.com/hubverse-org/hubExamples/issues/63

However, the changes in this PR are still something worth implementing despite not being the result of the CI check failures. The original PR description is preserved below the horizontal line.

---

## Problem

All CI checks started failing after dplyr 1.2.1 was released on April 3, 2026 (see #188). The pattern used in three places to assign the ensemble `model_id` column:

```r
dplyr::mutate(model_id = model_id, .before = 1)
```

relies on implicit environment lookup — when `model_id` is not a column in the data frame, dplyr is expected to find it in the calling function's environment. dplyr 1.2.x tightened its data-masking scoping rules, breaking this lookup and causing `model_id` to not be added to the result. The downstream `purrr::list_rbind()` then produces a combined data frame without a `model_id` column, and `hubUtils::as_model_out_tbl()` errors trying to construct one from non-existent `team_abbr`/`model_abbr` columns:

```
Cannot create `model_id` column.
Required columns `model_abbr` and `team_abbr` missing from `tbl`.
```

## Fix

Replace implicit lookup with `.env$model_id` in all three locations to explicitly resolve the variable from the calling environment:

```r
dplyr::mutate(model_id = .env$model_id, .before = 1)
```

This is the idiomatic dplyr approach for disambiguating a function argument from a column name inside `mutate()`. Applied to:

- `R/linear_pool_sample.R`
- `R/linear_pool_quantile.R`
- `R/simple_ensemble.R`

Closes #188.