### PR TITLE
Add hubEnsembles paper citation to package, README, and website, plus Plausible analytics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubEnsembles (development version)
 
+* Added a citation to the accompanying paper (Shandross et al., 2026, *Statistics in Medicine*, doi:10.1002/sim.70333) via a new `inst/CITATION` file and a citation section in the README (#197)
+
 # hubEnsembles 1.0.0
 
 * `hubEnsembles.Rmd` article now explains how to ensemble samples using `linear_pool()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # hubEnsembles (development version)
 
-* Added a citation to the accompanying paper (Shandross et al., 2026, *Statistics in Medicine*, doi:10.1002/sim.70333) via a new `inst/CITATION` file and a citation section in the README (#197)
+* Added a citation to the accompanying paper (Shandross et al., 2026, *Statistics in Medicine*, doi:10.1002/sim.70333) via a new `inst/CITATION` file, a citation section in the README, and a link in the package vignette (#197)
 
 # hubEnsembles 1.0.0
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,6 +43,15 @@ remotes::install_github("hubverse-org/hubEnsembles")
 ```
 
 
+## Citation
+
+If you use hubEnsembles, please cite the accompanying paper, which describes the package and the ensemble methods it implements:
+
+> Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A, Consortium of Infectious Disease Modeling Hubs, Reich NG, Ray EL (2026). "Multi-Model Ensembles in Infectious Disease and Public Health: Methods, Interpretation, and Implementation in R." *Statistics in Medicine*, **45**(1-2), e70333. doi:[10.1002/sim.70333](https://doi.org/10.1002/sim.70333).
+
+You can also run `citation("hubEnsembles")` in R to get the citation in plain-text and BibTeX formats.
+
+
 ***
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ you can install the development version of hubEnsembles from
 remotes::install_github("hubverse-org/hubEnsembles")
 ```
 
+## Citation
+
+If you use hubEnsembles, please cite the accompanying paper, which
+describes the package and the ensemble methods it implements:
+
+> Shandross L, Howerton E, Contamin L, Hochheiser H, Krystalli A,
+> Consortium of Infectious Disease Modeling Hubs, Reich NG, Ray EL
+> (2026). “Multi-Model Ensembles in Infectious Disease and Public Health:
+> Methods, Interpretation, and Implementation in R.” *Statistics in
+> Medicine*, **45**(1-2), e70333.
+> doi:[10.1002/sim.70333](https://doi.org/10.1002/sim.70333).
+
+You can also run `citation("hubEnsembles")` in R to get the citation in
+plain-text and BibTeX formats.
+
 ------------------------------------------------------------------------
 
 ## Code of Conduct

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,14 @@
 url: https://hubverse-org.github.io/hubEnsembles/
 template:
   package: hubStyle
+  includes:
+    in_header: |
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-Kr5Qox45R69wdSN4HONdD.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
 development:
   mode: auto
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,22 @@
+citHeader("To cite the hubEnsembles package or the ensemble methods it implements, please cite:")
+
+bibentry(
+  bibtype  = "Article",
+  title    = "Multi-Model Ensembles in Infectious Disease and Public Health: Methods, Interpretation, and Implementation in R",
+  author   = c(
+    person("Li", "Shandross"),
+    person("Emily", "Howerton"),
+    person("Lucie", "Contamin"),
+    person("Harry", "Hochheiser"),
+    person("Anna", "Krystalli"),
+    person("Consortium of Infectious Disease Modeling Hubs"),
+    person("Nicholas G.", "Reich"),
+    person("Evan L.", "Ray")
+  ),
+  journal  = "Statistics in Medicine",
+  year     = "2026",
+  volume   = "45",
+  number   = "1-2",
+  pages    = "e70333",
+  doi      = "10.1002/sim.70333"
+)

--- a/vignettes/articles/hubEnsembles.Rmd
+++ b/vignettes/articles/hubEnsembles.Rmd
@@ -16,6 +16,8 @@ options(width = 200)
 
 The `hubEnsembles` package provides a flexible framework for aggregating model outputs, such as forecasts or projections, that are submitted to a hub by multiple models and combined into ensemble model outputs. The package includes two main functions: `simple_ensemble` and `linear_pool`. We illustrate these functions in this vignette, and briefly compare them.
 
+The ensemble methods implemented in this package, along with guidance on their interpretation and use, are described in more detail in the accompanying paper: Shandross et al. (2026), ["Multi-Model Ensembles in Infectious Disease and Public Health: Methods, Interpretation, and Implementation in R"](https://doi.org/10.1002/sim.70333), *Statistics in Medicine*. If you use `hubEnsembles` in your work, please cite this paper; run `citation("hubEnsembles")` in R for the full citation in plain-text and BibTeX formats.
+
 This vignette uses the following R packages:
 
 ```{r setup, message=FALSE}


### PR DESCRIPTION
Closes #197.

Adds the citation for the accompanying hubEnsembles paper (Shandross et al., 2026, *Statistics in Medicine*, doi:10.1002/sim.70333) to improve discoverability and better link the manuscript with the package.

Changes:
- **`inst/CITATION`** (new): standard `bibentry()` citation so `citation("hubEnsembles")`  returns the paper. Validated with `utils::readCitationFile()` — renders correct  plain-text and BibTeX, with the Consortium correctly treated as a group author.
- **README** (`.Rmd` + `.md`): new "Citation" section with the full reference and DOI link.
- **Website**: pkgdown automatically renders `inst/CITATION` on the "Authors and  Citation" page and adds a citation link to the sidebar — no config change needed.
- **`NEWS.md`**: added a development-version entry.

The citation matches the official hubverse citation at https://docs.hubverse.io/en/latest/overview/cite.html#hubensembles-package (the CITATION file lists all authors in full rather than the APA "et al." truncation).

Note: `README.md` was hand-synced with `README.Rmd`; the added section is plain markdown with no code chunks, so `devtools::build_readme()` produces identical output.